### PR TITLE
chore: Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Setup Go ${{ vars.GO_VERSION }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ vars.GO_VERSION }}
           cache: false


### PR DESCRIPTION
## Summary

- Pin all public GitHub Action tag references to full commit SHAs for supply chain security
- Version tags preserved as inline comments for readability
- Internal `grafana/` workflow references left as-is

## Why

Tag-based action references are mutable, a compromised tag can inject malicious code into CI without any visible change in workflow files. Pinning to immutable commit SHAs prevents this attack vector.