### PR TITLE
ci: pin third-party actions to commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go ${{ vars.GO_VERSION }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ vars.GO_VERSION }}
           cache: false


### PR DESCRIPTION
## What?

Pins `actions/setup-go` in the release workflow to the v6.4.0 commit SHA. Also bumps the version from v5 to v6.

## Why?

GitHub Action tag references like `@v5` are mutable. If `actions/setup-go` is compromised, an attacker can repoint the tag at malicious code and the next release run will pick it up silently. A commit SHA is immutable, so the workflow runs the exact code that was reviewed.

This repo had no renovate config, so the version drifted to v5 while peer repos moved on. The shared k6-core renovate config will take over future bumps after this lands.
